### PR TITLE
Return Recaptcha action and error-codes bugfix.

### DIFF
--- a/template.tpl
+++ b/template.tpl
@@ -241,11 +241,11 @@ if (requestPath === '/recaptcha' ||
             cookieOptions
           );
         }
-        const responseMsg = data.returnResponse ? JSON.stringify({status: 'success', score: response.score}) : 'success';
+        const responseMsg = data.returnResponse ? JSON.stringify({status: 'success', action: response.action, score: response.score}) : 'success';
         
         proxyResponse(responseMsg, {}, 200);
       } else {
-        fail(JSON.stringify({status: 'failure', errorCodes: data['error-codes']}));
+        fail(JSON.stringify({status: 'failure', errorCodes: response['error-codes']}));
       }
     }, {method: 'POST', timeout: 2000, headers: {'content-type': 'application/x-www-form-urlencoded'}}, postBody);
   }  


### PR DESCRIPTION
A single page can contain multiple actions that trigger a Recaptcha verification. Knowing which action triggered the returned score could be useful. The client-side callback also needs to be altered. Minor bug fix for returning error codes upon failure of the Recaptcha verification.